### PR TITLE
Changes to kernels to run on AMD GPUs

### DIFF
--- a/clamr_gpucheck.cpp
+++ b/clamr_gpucheck.cpp
@@ -261,7 +261,7 @@ int main(int argc, char **argv) {
    state->gpu_timers[STATE_TIMER_WRITE] += ezcl_timer_calc(&start_write_event, &end_write_event);
 
 
-   if (ezcl_get_compute_device() == COMPUTE_DEVICE_ATI) enhanced_precision_sum = false;
+   if (ezcl_get_compute_device() == COMPUTE_DEVICE_AMD) enhanced_precision_sum = false;
 
    //  Kahan-type enhanced precision sum implementation.
    double H_sum = state->mass_sum(enhanced_precision_sum);

--- a/clamr_gpuonly.cpp
+++ b/clamr_gpuonly.cpp
@@ -255,7 +255,7 @@ int main(int argc, char **argv) {
 
    state->dev_mpot = NULL;
 
-   if (ezcl_get_compute_device() == COMPUTE_DEVICE_ATI) enhanced_precision_sum = false;
+   if (ezcl_get_compute_device() == COMPUTE_DEVICE_AMD) enhanced_precision_sum = false;
 
    //  Kahan-type enhanced precision sum implementation.
    double H_sum = state->gpu_mass_sum(enhanced_precision_sum);

--- a/embed_source.pl
+++ b/embed_source.pl
@@ -16,6 +16,7 @@ while(<>) {
    chop $_;
 
    s/"/""/g;
+   s/\\/\\\\/g;
 
 #   if (/^\/\*/){
 #      #print "Setting comment to 1\n";

--- a/experimental_iterative_state.cpp
+++ b/experimental_iterative_state.cpp
@@ -188,7 +188,7 @@ void State::init(int do_gpu_calc)
 #ifdef HAVE_OPENCL
       cl_context context = ezcl_get_context();
 
-      if (ezcl_get_compute_device() == COMPUTE_DEVICE_ATI) printf("Starting compile of kernels in state\n");
+      printf("Starting compile of kernels in state\n");
       const char *defines = NULL;
       cl_program program                 = ezcl_create_program_wsource(context, defines, state_kern_source);
 
@@ -207,7 +207,7 @@ void State::init(int do_gpu_calc)
       kernel_reduce_epsum_mass_stage2of2     = ezcl_create_kernel_wprogram(program, "reduce_epsum_mass_stage2of2_cl");
 
       ezcl_program_release(program);
-      if (ezcl_get_compute_device() == COMPUTE_DEVICE_ATI) printf("Finishing compile of kernels in state\n");
+      printf("Finishing compile of kernels in state\n");
 #endif
    }
 

--- a/ezcl/ezcl.c
+++ b/ezcl/ezcl.c
@@ -502,7 +502,7 @@ cl_int ezcl_devtype_init_p(cl_device_type device_type, const char *file, int lin
 
    clGetDeviceInfo(devices[0], CL_DEVICE_VENDOR, sizeof(info), &info, NULL);
    if (! strncmp(info,"NVIDIA",(size_t)6) ) compute_device = COMPUTE_DEVICE_NVIDIA;
-   if (! strncmp(info,"Advanced Micro Devices",(size_t)6) ) compute_device = COMPUTE_DEVICE_ATI;
+   if (! strncmp(info,"Advanced Micro Devices",(size_t)6) ) compute_device = COMPUTE_DEVICE_AMD;
    if (! strncmp(info,"Intel(R) Corporation",(size_t)6) ) compute_device = COMPUTE_DEVICE_INTEL;
    //printf("DEBUG -- device vendor is |%s|, compute_device %d\n",info,compute_device);
 
@@ -1482,6 +1482,14 @@ cl_kernel ezcl_create_kernel_p(cl_context context, const char *filename, const c
    if (compute_device == COMPUTE_DEVICE_NVIDIA) {
       strcat(CompileString," -DIS_NVIDIA");
    }
+   else if (compute_device == COMPUTE_DEVICE_AMD) {
+      strcat(CompileString, " -DIS_AMD -DMIN_REDUCE_SYNC_SIZE=64");
+   }
+   else
+   {
+        printf("EZCL_CREATE_KERNEL: Not supporting anything other than AMD or NVIDIA at the moment\n");
+        exit(EXIT_FAILURE);
+   }
 
    ierr = clBuildProgram(program, 0, NULL, CompileString, NULL, NULL);
 
@@ -1636,6 +1644,14 @@ cl_kernel ezcl_create_kernel_wsource_p(cl_context context, const char *source, c
 
    if (compute_device == COMPUTE_DEVICE_NVIDIA) {
       strcat(CompileString," -DIS_NVIDIA");
+   }
+   else if (compute_device == COMPUTE_DEVICE_AMD) {
+      strcat(CompileString, " -DIS_AMD -DMIN_REDUCE_SYNC_SIZE=64");
+   }
+   else
+   {
+        printf("EZCL_CREATE_KERNEL: Not supporting anything other than AMD or NVIDIA at the moment\n");
+        exit(EXIT_FAILURE);
    }
 
    ierr = clBuildProgram(program, 0, NULL, CompileString, NULL, NULL);
@@ -1793,7 +1809,15 @@ cl_program ezcl_create_program_wsource_p(cl_context context, const char *defines
 #endif
 
    if (compute_device == COMPUTE_DEVICE_NVIDIA) {
-      strcat(CompileString, " -DIS_NVIDIA");
+      strcat(CompileString, " -DIS_NVIDIA -DMIN_REDUCE_SYNC_SIZE=32");
+   }
+   else if (compute_device == COMPUTE_DEVICE_AMD) {
+      strcat(CompileString, " -DIS_AMD -DMIN_REDUCE_SYNC_SIZE=64");
+   }
+   else
+   {
+        printf("EZCL_CREATE_KERNEL: Not supporting anything other than AMD or NVIDIA at the moment\n");
+        exit(EXIT_FAILURE);
    }
 
    //printf("DEBUG file %s line %d CompileString %s\n",__FILE__,__LINE__,CompileString);

--- a/ezcl/ezcl.h
+++ b/ezcl/ezcl.h
@@ -89,7 +89,7 @@ typedef cl_float4 cl_real4;
 #define EZCL_MANAGED_MEMORY  0x0002
 
 #define COMPUTE_DEVICE_NVIDIA   1
-#define COMPUTE_DEVICE_ATI      2
+#define COMPUTE_DEVICE_AMD      2
 #define COMPUTE_DEVICE_INTEL    3
 
 #ifdef __cplusplus

--- a/graphics/display.h
+++ b/graphics/display.h
@@ -72,16 +72,16 @@
 #endif
 #endif
 
+#ifdef HAVE_MPI
+#include <mpi.h>
+#endif
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
 #define OMPI_SKIP_MPICXX 1
-
-#ifdef HAVE_MPI
-#include <mpi.h>
-#endif
 
 #ifdef HAVE_MPE
 #ifndef HAVE_MPI

--- a/mesh/embed_source.pl
+++ b/mesh/embed_source.pl
@@ -16,6 +16,7 @@ while(<>) {
    chop $_;
 
    s/"/""/g;
+   s/\\/\\\\/g;
 
 #   if (/^\/\*/){
 #      #print "Setting comment to 1\n";

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -1365,7 +1365,7 @@ void Mesh::init(int nx, int ny, real_t circ_radius, partition_method initial_ord
       cl_context context = ezcl_get_context();
 
       hash_lib_init();
-      if (ezcl_get_compute_device() == COMPUTE_DEVICE_ATI) printf("Starting compile of kernels in mesh\n");
+      printf("Starting compile of kernels in mesh\n");
       char *bothsources = (char *)malloc(strlen(mesh_kern_source)+strlen(get_hash_kernel_source_string())+1);
       strcpy(bothsources, get_hash_kernel_source_string());
       strcat(bothsources, mesh_kern_source);
@@ -1425,7 +1425,7 @@ void Mesh::init(int nx, int ny, real_t circ_radius, partition_method initial_ord
       }
 
       ezcl_program_release(program);
-      if (ezcl_get_compute_device() == COMPUTE_DEVICE_ATI) printf("Finishing compile of kernels in mesh\n");
+      printf("Finishing compile of kernels in mesh\n");
 #endif
    }
 

--- a/mesh/mesh_kern.cl
+++ b/mesh/mesh_kern.cl
@@ -1917,7 +1917,7 @@ void reduction_minmax_within_tile4(__local  int4  *tile)
    const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
 
-    for (int offset=ntX>>1; offset > 32; offset >>= 1){
+    for (int offset=ntX>>1; offset > MIN_REDUCE_SYNC_SIZE; offset >>= 1){
       if (tiX < offset){
         if (tile[tiX+offset].s0 < tile[tiX].s0) tile[tiX].s0 = tile[tiX+offset].s0;
         if (tile[tiX+offset].s1 > tile[tiX].s1) tile[tiX].s1 = tile[tiX+offset].s1;
@@ -1927,41 +1927,21 @@ void reduction_minmax_within_tile4(__local  int4  *tile)
       barrier(CLK_LOCAL_MEM_FENCE);
     }
 
-    if (tiX < 32){
-      if (tile[tiX+32].s0 < tile[tiX].s0) tile[tiX].s0 = tile[tiX+32].s0;
-      if (tile[tiX+32].s1 > tile[tiX].s1) tile[tiX].s1 = tile[tiX+32].s1;
-      if (tile[tiX+32].s2 < tile[tiX].s2) tile[tiX].s2 = tile[tiX+32].s2;
-      if (tile[tiX+32].s3 > tile[tiX].s3) tile[tiX].s3 = tile[tiX+32].s3;
-      barrier(CLK_LOCAL_MEM_FENCE);
+    if (tiX < MIN_REDUCE_SYNC_SIZE)
+    {
+        for (int offset = MIN_REDUCE_SYNC_SIZE; offset > 1; offset >>= 1)
+        {
+            if (tile[tiX + offset].s0 < tile[tiX].s0) tile[tiX].s0 = tile[tiX + offset].s0;
+            if (tile[tiX + offset].s1 > tile[tiX].s1) tile[tiX].s1 = tile[tiX + offset].s1;
+            if (tile[tiX + offset].s2 < tile[tiX].s2) tile[tiX].s2 = tile[tiX + offset].s2;
+            if (tile[tiX + offset].s3 > tile[tiX].s3) tile[tiX].s3 = tile[tiX + offset].s3;
+            barrier(CLK_LOCAL_MEM_FENCE);
+        }
 
-      if (tile[tiX+16].s0 < tile[tiX].s0) tile[tiX].s0 = tile[tiX+16].s0;
-      if (tile[tiX+16].s1 > tile[tiX].s1) tile[tiX].s1 = tile[tiX+16].s1;
-      if (tile[tiX+16].s2 < tile[tiX].s2) tile[tiX].s2 = tile[tiX+16].s2;
-      if (tile[tiX+16].s3 > tile[tiX].s3) tile[tiX].s3 = tile[tiX+16].s3;
-      barrier(CLK_LOCAL_MEM_FENCE);
-
-      if (tile[tiX+8].s0 < tile[tiX].s0) tile[tiX].s0 = tile[tiX+8].s0;
-      if (tile[tiX+8].s1 > tile[tiX].s1) tile[tiX].s1 = tile[tiX+8].s1;
-      if (tile[tiX+8].s2 < tile[tiX].s2) tile[tiX].s2 = tile[tiX+8].s2;
-      if (tile[tiX+8].s3 > tile[tiX].s3) tile[tiX].s3 = tile[tiX+8].s3;
-      barrier(CLK_LOCAL_MEM_FENCE);
-
-      if (tile[tiX+4].s0 < tile[tiX].s0) tile[tiX].s0 = tile[tiX+4].s0;
-      if (tile[tiX+4].s1 > tile[tiX].s1) tile[tiX].s1 = tile[tiX+4].s1;
-      if (tile[tiX+4].s2 < tile[tiX].s2) tile[tiX].s2 = tile[tiX+4].s2;
-      if (tile[tiX+4].s3 > tile[tiX].s3) tile[tiX].s3 = tile[tiX+4].s3;
-      barrier(CLK_LOCAL_MEM_FENCE);
-
-      if (tile[tiX+2].s0 < tile[tiX].s0) tile[tiX].s0 = tile[tiX+2].s0;
-      if (tile[tiX+2].s1 > tile[tiX].s1) tile[tiX].s1 = tile[tiX+2].s1;
-      if (tile[tiX+2].s2 < tile[tiX].s2) tile[tiX].s2 = tile[tiX+2].s2;
-      if (tile[tiX+2].s3 > tile[tiX].s3) tile[tiX].s3 = tile[tiX+2].s3;
-      barrier(CLK_LOCAL_MEM_FENCE);
-
-      if (tile[tiX+1].s0 < tile[tiX].s0) tile[tiX].s0 = tile[tiX+1].s0;
-      if (tile[tiX+1].s1 > tile[tiX].s1) tile[tiX].s1 = tile[tiX+1].s1;
-      if (tile[tiX+1].s2 < tile[tiX].s2) tile[tiX].s2 = tile[tiX+1].s2;
-      if (tile[tiX+1].s3 > tile[tiX].s3) tile[tiX].s3 = tile[tiX+1].s3;
+        if (tile[tiX + 1].s0 < tile[tiX].s0) tile[tiX].s0 = tile[tiX + 1].s0;
+        if (tile[tiX + 1].s1 > tile[tiX].s1) tile[tiX].s1 = tile[tiX + 1].s1;
+        if (tile[tiX + 1].s2 < tile[tiX].s2) tile[tiX].s2 = tile[tiX + 1].s2;
+        if (tile[tiX + 1].s3 > tile[tiX].s3) tile[tiX].s3 = tile[tiX + 1].s3;
     }
 }
 

--- a/mesh/mesh_kern.cl
+++ b/mesh/mesh_kern.cl
@@ -717,7 +717,7 @@ inline uint scan_workgroup_exclusive(
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // Step 2: Collect per-warp sums
-    if (lane == 31) itile[warpID] = itile[tiX];
+    if (lane == (MIN_REDUCE_SYNC_SIZE - 1)) itile[warpID] = itile[tiX];
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // Step 3: Use 1st warp to scan per-warp sums
@@ -746,7 +746,7 @@ inline int2 scan_workgroup_exclusive2(
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // Step 2: Collect per-warp sums
-    if (lane == 31) itile[warpID].s01 = itile[tiX].s01;
+    if (lane == (MIN_REDUCE_SYNC_SIZE - 1)) itile[warpID].s01 = itile[tiX].s01;
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // Step 3: Use 1st warp to scan per-warp sums
@@ -774,8 +774,8 @@ __kernel void finish_scan_cl(
    const uint group_id = get_group_id(0);
    const uint ntX = get_local_size(0);
 
-   const uint lane = tiX & 31; 
-   const uint warpID = tiX >> 5;
+   const uint lane = tiX & (MIN_REDUCE_SYNC_SIZE - 1); 
+   const uint warpID = tiX >> N_BITS_WARP_LENGTH;
    const uint EPT = (size+ntX-1)/ntX; //elements_per_thread;
 
    uint reduceValue = 0;
@@ -832,8 +832,8 @@ __kernel void get_border_data_cl(
    const uint tiX = get_local_id(0);
    const uint group_id = get_group_id(0);
 
-   const uint lane   = tiX & 31; 
-   const uint warpid = tiX >> 5;
+   const uint lane   = tiX & (MIN_REDUCE_SYNC_SIZE - 1); 
+   const uint warpid = tiX >> N_BITS_WARP_LENGTH;
 
    int cell_num = giX-noffset;
 
@@ -849,7 +849,7 @@ __kernel void get_border_data_cl(
    barrier(CLK_LOCAL_MEM_FENCE);
 
    // Step 3: Collect per-warp sums
-   if (lane == 31) itile[warpid] = itile[tiX];
+   if (lane == (MIN_REDUCE_SYNC_SIZE - 1)) itile[warpid] = itile[tiX];
    barrier(CLK_LOCAL_MEM_FENCE);
 
    // Step 4: Use 1st warp to scan per-warp sums
@@ -1344,8 +1344,8 @@ __kernel void get_border_data2_cl(
    const uint tiX = get_local_id(0);
    const uint group_id = get_group_id(0);
 
-   const uint lane   = tiX & 31; 
-   const uint warpid = tiX >> 5;
+   const uint lane   = tiX & (MIN_REDUCE_SYNC_SIZE - 1); 
+   const uint warpid = tiX >> N_BITS_WARP_LENGTH;
 
    // Step 1: load global data into tile
    int temp_val = 0;
@@ -1359,7 +1359,7 @@ __kernel void get_border_data2_cl(
    barrier(CLK_LOCAL_MEM_FENCE);
 
    // Step 3: Collect per-warp sums
-   if (lane == 31) itile[warpid] = itile[tiX];
+   if (lane == (MIN_REDUCE_SYNC_SIZE - 1)) itile[warpid] = itile[tiX];
    barrier(CLK_LOCAL_MEM_FENCE);
 
    // Step 4: Use 1st warp to scan per-warp sums
@@ -1920,8 +1920,8 @@ __kernel void finish_reduction_scan2_cl(
    const uint gID = get_group_id(0);
    const uint ntX = get_local_size(0);
 
-   const uint lane = tiX & 31;
-   const uint warpID = tiX >> 5;
+   const uint lane = tiX & (MIN_REDUCE_SYNC_SIZE - 1);
+   const uint warpID = tiX >> N_BITS_WARP_LENGTH;
    const uint EPT = (isize+ntX-1)/ntX; //elements_per_thread;
    const uint BLOCK_SIZE = EPT * ntX;
 
@@ -2656,8 +2656,8 @@ __kernel void rezone_all_cl(
    uint ntX = get_local_size(0);
    uint group_id = get_group_id(0);
 
-   const uint lane   = tiX & 31;
-   const uint warpid = tiX >> 5;
+   const uint lane   = tiX & (MIN_REDUCE_SYNC_SIZE - 1);
+   const uint warpid = tiX >> N_BITS_WARP_LENGTH;
 
    // Step 1: load global data into tile
    uint indexval=0;
@@ -2691,7 +2691,7 @@ __kernel void rezone_all_cl(
    barrier(CLK_LOCAL_MEM_FENCE);
 
    // Step 3: Collect per-warp sums
-   if (lane == 31) itile[warpid] = itile[tiX];
+   if (lane == (MIN_REDUCE_SYNC_SIZE - 1)) itile[warpid] = itile[tiX];
    barrier(CLK_LOCAL_MEM_FENCE);
 
    // Step 4: Use 1st warp to scan per-warp sums

--- a/mesh/mesh_kern.cl
+++ b/mesh/mesh_kern.cl
@@ -674,7 +674,7 @@ __kernel void calc_border_cells2_cl(
 }
 
 inline uint scan_warp_exclusive(__local volatile uint *input, const uint idx, const uint lane) {
-    for (int offset = 1; offset < MIN_REDUCE_SYNC_SIZE; offset *= 2)
+    for (int offset = 1; offset < MIN_REDUCE_SYNC_SIZE; offset <<= 1)
     {
         if (lane > (offset - 1)) input[idx] += input[idx - offset];
     }
@@ -683,7 +683,7 @@ inline uint scan_warp_exclusive(__local volatile uint *input, const uint idx, co
 }
 
 inline uint scan_warp_inclusive(__local volatile uint *input, const uint idx, const uint lane) {
-    for (int offset = 1; offset < MIN_REDUCE_SYNC_SIZE; offset *= 2)
+    for (int offset = 1; offset < MIN_REDUCE_SYNC_SIZE; offset <<= 1)
     {
         if (lane > (offset - 1)) input[idx] += input[idx - offset];
     }
@@ -694,7 +694,7 @@ inline uint scan_warp_inclusive(__local volatile uint *input, const uint idx, co
 inline int2 scan_warp_exclusive2(__local volatile int2 *input, const uint idx, const uint lane) {
     int2 zero = 0;
 
-    for (int offset = 1; offset < MIN_REDUCE_SYNC_SIZE; offset *= 2)
+    for (int offset = 1; offset < MIN_REDUCE_SYNC_SIZE; offset <<= 1)
     {
         if (lane > (offset - 1)) input[idx].s01 += input[idx - offset].s01;
     }
@@ -703,7 +703,7 @@ inline int2 scan_warp_exclusive2(__local volatile int2 *input, const uint idx, c
 }
 
 inline int2 scan_warp_inclusive2(__local volatile int2 *input, const uint idx, const uint lane) {
-    for (int offset = 1; offset < MIN_REDUCE_SYNC_SIZE; offset *= 2)
+    for (int offset = 1; offset < MIN_REDUCE_SYNC_SIZE; offset <<= 1)
     {
         if (lane > (offset - 1)) input[idx].s01 += input[idx - offset].s01;
     }
@@ -2930,7 +2930,7 @@ __kernel void rezone_all_cl(
          } // End local stencil version
 
          for (int ii = 0; ii < 4; ii++){
-#ifdef IS_NVIDIA
+#if 1
             switch (order[ii]) {
             case SW:
                 // lower left

--- a/mesh/mesh_kern.cl
+++ b/mesh/mesh_kern.cl
@@ -1914,8 +1914,8 @@ __kernel void finish_reduction_scan2_cl(
 
 void reduction_minmax_within_tile4(__local  int4  *tile)
 {
-   const unsigned int tiX  = get_local_id(0);
-   const unsigned int ntX  = get_local_size(0);
+    const unsigned int tiX  = get_local_id(0);
+    const unsigned int ntX  = get_local_size(0);
 
     for (int offset=ntX>>1; offset > MIN_REDUCE_SYNC_SIZE; offset >>= 1){
       if (tiX < offset){
@@ -3260,8 +3260,8 @@ __kernel void set_boundary_refinement(
 
 void reduction_sum_int2_within_tile(__local  int2  *itile)
 {
-   const unsigned int tiX  = get_local_id(0);
-   const unsigned int ntX  = get_local_size(0);
+    const unsigned int tiX  = get_local_id(0);
+    const unsigned int ntX  = get_local_size(0);
 
     for (int offset = ntX >> 1; offset > MIN_REDUCE_SYNC_SIZE; offset >>= 1)
     {

--- a/mesh/reduce.cl
+++ b/mesh/reduce.cl
@@ -89,15 +89,6 @@ void reduction_min_within_tile(__local  real  *tile);
 		   MPI_SUM                 MPI_Op
 */
 
-#if defined(IS_NVIDIA)
-#define MIN_REDUCE_SYNC_SIZE 32
-#elif defined(IS_AMD)
-#define MIN_REDUCE_SYNC_SIZE 64
-//#elif defined(IS_INTEL) ? Not sure what the minimum would be on this
-#else
-#define MIN_REDUCE_SYNC_SIZE 1
-#endif
-
 int SUM_INT(int a, int b)
 {
     return a + b;

--- a/mesh/reduce.cl
+++ b/mesh/reduce.cl
@@ -123,11 +123,12 @@ real MIN(real a, real b)
         }                                                                       \
         barrier(CLK_LOCAL_MEM_FENCE);                                           \
     }                                                                           \
-    if (tiX == 0)                                                               \
+    if (tiX < 32)                                                               \
     {                                                                           \
         for (int offset = MIN_REDUCE_SYNC_SIZE; offset > 1; offset >>= 1)       \
         {                                                                       \
             _tile_arr[tiX] = operation(_tile_arr[tiX], _tile_arr[tiX+offset]);  \
+            barrier(CLK_LOCAL_MEM_FENCE);                                       \
         }                                                                       \
         _tile_arr[tiX] = operation(_tile_arr[tiX], _tile_arr[tiX+1]);           \
     }

--- a/mesh/reduce.cl
+++ b/mesh/reduce.cl
@@ -123,7 +123,7 @@ real MIN(real a, real b)
         }                                                                       \
         barrier(CLK_LOCAL_MEM_FENCE);                                           \
     }                                                                           \
-    if (tiX < 32)                                                               \
+    if (tiX < MIN_REDUCE_SYNC_SIZE)                                             \
     {                                                                           \
         for (int offset = MIN_REDUCE_SYNC_SIZE; offset > 1; offset >>= 1)       \
         {                                                                       \

--- a/mesh/reduce.cl
+++ b/mesh/reduce.cl
@@ -125,7 +125,7 @@ real MIN(real a, real b)
     }                                                                           \
     if (tiX == 0)                                                               \
     {                                                                           \
-        for (int offset = 0; offset > 1; offset >>= 1)                          \
+        for (int offset = MIN_REDUCE_SYNC_SIZE; offset > 1; offset >>= 1)       \
         {                                                                       \
             _tile_arr[tiX] = operation(_tile_arr[tiX], _tile_arr[tiX+offset]);  \
         }                                                                       \

--- a/mesh/reduce.cl
+++ b/mesh/reduce.cl
@@ -2,12 +2,12 @@
  *  Copyright (c) 2011-2012, Los Alamos National Security, LLC.
  *  All rights Reserved.
  *
- *  Copyright 2011-2012. Los Alamos National Security, LLC. This software was produced 
- *  under U.S. Government contract DE-AC52-06NA25396 for Los Alamos National 
- *  Laboratory (LANL), which is operated by Los Alamos National Security, LLC 
- *  for the U.S. Department of Energy. The U.S. Government has rights to use, 
- *  reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR LOS 
- *  ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR 
+ *  Copyright 2011-2012. Los Alamos National Security, LLC. This software was produced
+ *  under U.S. Government contract DE-AC52-06NA25396 for Los Alamos National
+ *  Laboratory (LANL), which is operated by Los Alamos National Security, LLC
+ *  for the U.S. Department of Energy. The U.S. Government has rights to use,
+ *  reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR LOS
+ *  ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
  *  ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is modified
  *  to produce derivative works, such modified software should be clearly marked,
  *  so as not to confuse it with the version available from LANL.
@@ -19,13 +19,13 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Los Alamos National Security, LLC, Los Alamos 
- *       National Laboratory, LANL, the U.S. Government, nor the names of its 
- *       contributors may be used to endorse or promote products derived from 
+ *     * Neither the name of the Los Alamos National Security, LLC, Los Alamos
+ *       National Laboratory, LANL, the U.S. Government, nor the names of its
+ *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
- *  
- *  THIS SOFTWARE IS PROVIDED BY THE LOS ALAMOS NATIONAL SECURITY, LLC AND 
- *  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT 
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE LOS ALAMOS NATIONAL SECURITY, LLC AND
+ *  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
  *  NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
  *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL LOS ALAMOS NATIONAL
  *  SECURITY, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -35,23 +35,23 @@
  *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
- *  
+ *
  *  CLAMR -- LA-CC-11-094
- *  This research code is being developed as part of the 
+ *  This research code is being developed as part of the
  *  2011 X Division Summer Workshop for the express purpose
  *  of a collaborative code for development of ideas in
  *  the implementation of AMR codes for Exascale platforms
- *  
+ *
  *  AMR implementation of the Wave code previously developed
  *  as a demonstration code for regular grids on Exascale platforms
- *  as part of the Supercomputing Challenge and Los Alamos 
+ *  as part of the Supercomputing Challenge and Los Alamos
  *  National Laboratory
- *  
+ *
  *  Authors: Bob Robey       XCP-2   brobey@lanl.gov
  *           Neal Davis              davis68@lanl.gov, davis68@illinois.edu
  *           David Nicholaeff        dnic@lanl.gov, mtrxknight@aol.com
  *           Dennis Trujillo         dptrujillo@lanl.gov, dptru10@gmail.com
- * 
+ *
  */
 #ifndef GPU_DOUBLE_SUPPORT
 #define GPU_DOUBLE_SUPPORT
@@ -69,6 +69,10 @@ typedef float   real;
 #endif
 #endif
 
+void reduction_sum_within_tile(__local  real  *tile);
+void reduction_max_within_tile(__local  real  *tile);
+void reduction_min_within_tile(__local  real  *tile);
+
 /*
 		   MPI_BAND                MPI_Op
 		   MPI_BOR                 MPI_Op
@@ -85,36 +89,76 @@ typedef float   real;
 		   MPI_SUM                 MPI_Op
 */
 
+#if defined(IS_NVIDIA)
+#define MIN_REDUCE_SYNC_SIZE 32
+#elif defined(IS_AMD)
+#define MIN_REDUCE_SYNC_SIZE 64
+//#elif defined(IS_INTEL) ? Not sure what the minimum would be on this
+#else
+#define MIN_REDUCE_SYNC_SIZE 1
+#endif
+
+int SUM_INT(int a, int b)
+{
+    return a + b;
+}
+
+real SUM(real a, real b)
+{
+    return a + b;
+}
+
+real PROD(real a, real b)
+{
+    return a * b;
+}
+
+real MAX(real a, real b)
+{
+    return max(a, b);
+}
+
+real MIN(real a, real b)
+{
+    return min(a, b);
+}
+
+#define REDUCE_IN_TILE(operation)                                               \
+    for (int offset = ntX >> 1; offset > MIN_REDUCE_SYNC_SIZE; offset >>= 1)     \
+    {                                                                               \
+        if (tiX < offset)                                                         \
+        {                                                                       \
+            tile[tiX] = operation(tile[tiX], tile[tiX+offset]);                     \
+        }                                                                       \
+        barrier(CLK_LOCAL_MEM_FENCE);                                               \
+    }                                                                           \
+    if (tiX == 0)                                                                \
+    {                                                                            \
+        for (int offset = 0; offset > 1; offset >>= 1)                           \
+        {                                                                        \
+            tile[tiX] = operation(tile[tiX], tile[tiX+offset]);                     \
+        }                                                                        \
+        tile[tiX] = operation(tile[tiX], tile[tiX+1]);                           \
+    }
+
 __kernel void reduce_sum_cl(
                  const int    isize,    // 0   Array length.
         __global       real  *array,    // 1   Array to be reduced.
         __global       real  *result,   // 2   Final result of operation.
-        __local        real  *tile)     // 3   
+        __local        real  *tile)     // 3
 {  const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
-   
+
    int giX = tiX;
-   
+
    tile[tiX] = array[giX];
-   
+
    for (giX += ntX; giX < isize; giX += ntX)
    {  tile[tiX] += array[giX]; }
    barrier(CLK_LOCAL_MEM_FENCE);
-   
-   for (int offset = ntX >> 1; offset > 32; offset >>= 1)
-   {  if (tiX < offset)
-      {  tile[tiX] += tile[tiX+offset]; }
-      barrier(CLK_LOCAL_MEM_FENCE); }
-   
-   //  Unroll the remainder of the loop as 32 threads must proceed in lockstep.
-   if (tiX < 32)
-   {  tile[tiX] += tile[tiX+32];
-      tile[tiX] += tile[tiX+16];
-      tile[tiX] += tile[tiX+8];
-      tile[tiX] += tile[tiX+4];
-      tile[tiX] += tile[tiX+2];
-      tile[tiX] += tile[tiX+1]; }
-   
+
+   reduction_sum_within_tile(tile);
+
    if (tiX == 0)
    {  result[0] = tile[0]; }
 }
@@ -123,32 +167,20 @@ __kernel void reduce_product_cl(
                  const int    isize,    // 0   Array length.
         __global       real  *array,    // 1   Array to be reduced.
         __global       real  *result,   // 2   Final result of operation.
-        __local        real  *tile)     // 3   
+        __local        real  *tile)     // 3
 {  const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
-   
+
    int giX = tiX;
-   
+
    tile[tiX] = array[giX];
-   
+
    for (giX += ntX; giX < isize; giX += ntX)
    {  tile[tiX] *= array[giX]; }
    barrier(CLK_LOCAL_MEM_FENCE);
-   
-   for (int offset = ntX >> 1; offset > 32; offset >>= 1)
-   {  if (tiX < offset)
-      {  tile[tiX] *= tile[tiX+offset]; }
-      barrier(CLK_LOCAL_MEM_FENCE); }
-   
-   //  Unroll the remainder of the loop as 32 threads must proceed in lockstep.
-   if (tiX < 32)
-   {  tile[tiX] *= tile[tiX+32];
-      tile[tiX] *= tile[tiX+16];
-      tile[tiX] *= tile[tiX+8];
-      tile[tiX] *= tile[tiX+4];
-      tile[tiX] *= tile[tiX+2];
-      tile[tiX] *= tile[tiX+1]; }
-   
+
+   REDUCE_IN_TILE(PROD);
+
    if (tiX == 0)
    {  result[0] = tile[0]; }
 }
@@ -157,32 +189,20 @@ __kernel void reduce_max_cl(
                  const int    isize,    // 0   Array length.
         __global       real  *array,    // 1   Array to be reduced.
         __global       real  *result,   // 2   Final result of operation.
-        __local        real  *tile)     // 3   
+        __local        real  *tile)     // 3
 {  const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
-   
+
    int giX = tiX;
-   
+
    tile[tiX] = array[giX];
-   
+
    for (giX += ntX; giX < isize; giX += ntX)
    {  if (array[giX] > tile[tiX]) tile[tiX] = array[giX]; }
    barrier(CLK_LOCAL_MEM_FENCE);
-   
-   for (int offset = ntX >> 1; offset > 32; offset >>= 1)
-   {  if (tiX < offset)
-      {  if (array[giX+offset] > tile[tiX]) tile[tiX] = tile[tiX+offset]; }
-      barrier(CLK_LOCAL_MEM_FENCE); }
-   
-   //  Unroll the remainder of the loop as 32 threads must proceed in lockstep.
-   if (tiX < 32)
-   {  if (array[giX+32] > tile[tiX]) tile[tiX] = tile[tiX+32];
-      if (array[giX+16] > tile[tiX]) tile[tiX] = tile[tiX+16];
-      if (array[giX+8] > tile[tiX]) tile[tiX] = tile[tiX+8];
-      if (array[giX+4] > tile[tiX]) tile[tiX] = tile[tiX+4];
-      if (array[giX+2] > tile[tiX]) tile[tiX] = tile[tiX+2];
-      if (array[giX+1] > tile[tiX]) tile[tiX] = tile[tiX+1]; }
-   
+
+   reduction_max_within_tile(tile);
+
    if (tiX == 0)
    {  result[0] = tile[0]; }
 }
@@ -192,32 +212,20 @@ __kernel void reduce_min_cl(
                  const int    isize,    // 0   Array length.
         __global       real  *array,    // 1   Array to be reduced.
         __global       real  *result,   // 2   Final result of operation.
-        __local        real  *tile)     // 3   
+        __local        real  *tile)     // 3
 {  const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
-   
+
    int giX = tiX;
-   
+
    tile[tiX] = array[giX];
-   
+
    for (giX += ntX; giX < isize; giX += ntX)
    {  if (array[giX] < tile[tiX]) tile[tiX] = array[giX]; }
    barrier(CLK_LOCAL_MEM_FENCE);
-   
-   for (int offset = ntX >> 1; offset > 32; offset >>= 1)
-   {  if (tiX < offset)
-      {  if (array[giX+offset] < tile[tiX]) tile[tiX] = tile[tiX+offset]; }
-      barrier(CLK_LOCAL_MEM_FENCE); }
-   
-   //  Unroll the remainder of the loop as 32 threads must proceed in lockstep.
-   if (tiX < 32)
-   {  if (array[giX+32] < tile[tiX]) tile[tiX] = tile[tiX+32];
-      if (array[giX+16] < tile[tiX]) tile[tiX] = tile[tiX+16];
-      if (array[giX+8] < tile[tiX]) tile[tiX] = tile[tiX+8];
-      if (array[giX+4] < tile[tiX]) tile[tiX] = tile[tiX+4];
-      if (array[giX+2] < tile[tiX]) tile[tiX] = tile[tiX+2];
-      if (array[giX+1] < tile[tiX]) tile[tiX] = tile[tiX+1]; }
-   
+
+   reduction_min_within_tile(tile);
+
    if (tiX == 0)
    {  result[0] = tile[0]; }
 }
@@ -226,23 +234,23 @@ __kernel void reduce_maxloc_cl(
                  const int    isize,    // 0   Array length.
         __global       real  *array,    // 1   Array to be reduced.
         __global       real  *result,   // 2   Final result of operation.
-        __local        real  *tile)     // 3   
+        __local        real  *tile)     // 3
 {  const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
-   
+
    int giX = tiX;
-   
+
    tile[tiX] = array[giX]; //XXX:IC?
-   
+
    for (giX += ntX; giX < isize; giX += ntX)
    {  if (array[giX] > tile[tiX]) tile[tiX] = giX; }
    barrier(CLK_LOCAL_MEM_FENCE);
-   
+
    for (int offset = ntX >> 1; offset > 32; offset >>= 1)
    {  if (tiX < offset)
       {  if (array[giX+offset] > tile[tiX]) tile[tiX] = tiX+offset; }
       barrier(CLK_LOCAL_MEM_FENCE); }
-   
+
    //  Unroll the remainder of the loop as 32 threads must proceed in lockstep.
    if (tiX < 32)
    {  if (array[giX+32] > tile[tiX]) tile[tiX] = tiX+32;
@@ -251,7 +259,7 @@ __kernel void reduce_maxloc_cl(
       if (array[giX+4] > tile[tiX]) tile[tiX] = tiX+4;
       if (array[giX+2] > tile[tiX]) tile[tiX] = tiX+2;
       if (array[giX+1] > tile[tiX]) tile[tiX] = tiX+1; }
-   
+
    if (tiX == 0)
    {  result[0] = tile[0]; }
 }
@@ -261,23 +269,23 @@ __kernel void reduce_minloc_cl(
                  const int    isize,    // 0   Array length.
         __global       real  *array,    // 1   Array to be reduced.
         __global       real  *result,   // 2   Final result of operation.
-        __local        real  *tile)     // 3   
+        __local        real  *tile)     // 3
 {  const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
-   
+
    int giX = tiX;
-   
+
    tile[tiX] = array[giX]; //XXX:IC?
-   
+
    for (giX += ntX; giX < isize; giX += ntX)
    {  if (array[giX] < tile[tiX]) tile[tiX] = giX; }
    barrier(CLK_LOCAL_MEM_FENCE);
-   
+
    for (int offset = ntX >> 1; offset > 32; offset >>= 1)
    {  if (tiX < offset)
       {  if (array[giX+offset] < tile[tiX]) tile[tiX] = tiX+offset; }
       barrier(CLK_LOCAL_MEM_FENCE); }
-   
+
    //  Unroll the remainder of the loop as 32 threads must proceed in lockstep.
    if (tiX < 32)
    {  if (array[giX+32] < tile[tiX]) tiX+32;
@@ -286,7 +294,7 @@ __kernel void reduce_minloc_cl(
       if (array[giX+4] < tile[tiX]) tiX+4;
       if (array[giX+2] < tile[tiX]) tiX+2;
       if (array[giX+1] < tile[tiX]) tiX+1; }
-   
+
    if (tiX == 0)
    {  result[0] = tile[0]; }
 }
@@ -299,13 +307,13 @@ void reduction_min_within_tile(__local  real  *tile);
 
 __kernel void reduce_sum_stage1of2_cl(
                  const int    isize,     // 0  Total number of cells.
-        __global const real  *array,     // 1  
-        __global       real  *scratch,   // 2 
+        __global const real  *array,     // 1
+        __global       real  *scratch,   // 2
         __local        real  *tile)      // 3
 {
     const unsigned int giX  = get_global_id(0);
     const unsigned int tiX  = get_local_id(0);
-    
+
     const unsigned int group_id = get_group_id(0);
 
     tile[tiX] = ZERO;
@@ -325,7 +333,7 @@ __kernel void reduce_sum_stage2of2_cl(
         const    int    isize,
         __global real  *scratch,
         __local  real  *tile)
-{       
+{
    const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
 
@@ -338,7 +346,7 @@ __kernel void reduce_sum_stage2of2_cl(
    for (giX += ntX; giX < isize; giX += ntX) {
      tile[tiX] += scratch[giX];
    }
- 
+
    barrier(CLK_LOCAL_MEM_FENCE);
 
    reduction_sum_within_tile(tile);
@@ -350,13 +358,13 @@ __kernel void reduce_sum_stage2of2_cl(
 
 __kernel void reduce_sum_int_stage1of2_cl(
                  const int    isize,     // 0  Total number of cells.
-        __global const int   *array,     // 1  
-        __global       int   *scratch,   // 2 
+        __global const int   *array,     // 1
+        __global       int   *scratch,   // 2
         __local        int   *tile)      // 3
 {
     const unsigned int giX  = get_global_id(0);
     const unsigned int tiX  = get_local_id(0);
-    
+
     const unsigned int group_id = get_group_id(0);
 
     tile[tiX] = ZERO;
@@ -376,7 +384,7 @@ __kernel void reduce_sum_int_stage2of2_cl(
         const    int    isize,
         __global int   *scratch,
         __local  int   *tile)
-{       
+{
    const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
 
@@ -389,7 +397,7 @@ __kernel void reduce_sum_int_stage2of2_cl(
    for (giX += ntX; giX < isize; giX += ntX) {
      tile[tiX] += scratch[giX];
    }
- 
+
    barrier(CLK_LOCAL_MEM_FENCE);
 
    reduction_sum_int_within_tile(tile);
@@ -401,13 +409,13 @@ __kernel void reduce_sum_int_stage2of2_cl(
 
 __kernel void reduce_max_stage1of2_cl(
                  const int    isize,     // 0  Total number of cells.
-        __global const real  *array,     // 1  
-        __global       real  *scratch,   // 2 
+        __global const real  *array,     // 1
+        __global       real  *scratch,   // 2
         __local        real  *tile)      // 3
 {
     const unsigned int giX  = get_global_id(0);
     const unsigned int tiX  = get_local_id(0);
-    
+
     const unsigned int group_id = get_group_id(0);
 
     tile[tiX] = MINUS_INFINITY;
@@ -427,7 +435,7 @@ __kernel void reduce_max_stage2of2_cl(
         const    int    isize,
         __global real  *scratch,
         __local  real  *tile)
-{       
+{
    const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
 
@@ -440,7 +448,7 @@ __kernel void reduce_max_stage2of2_cl(
    for (giX += ntX; giX < isize; giX += ntX) {
      if (scratch[giX] > tile[tiX]) tile[tiX] = scratch[giX];
    }
- 
+
    barrier(CLK_LOCAL_MEM_FENCE);
 
    reduction_max_within_tile(tile);
@@ -452,13 +460,13 @@ __kernel void reduce_max_stage2of2_cl(
 
 __kernel void reduce_min_stage1of2_cl(
                  const int    isize,     // 0  Total number of cells.
-        __global const real  *array,     // 1  
-        __global       real  *scratch,   // 2 
+        __global const real  *array,     // 1
+        __global       real  *scratch,   // 2
         __local        real  *tile)      // 3
 {
     const unsigned int giX  = get_global_id(0);
     const unsigned int tiX  = get_local_id(0);
-    
+
     const unsigned int group_id = get_group_id(0);
 
     tile[tiX] = PLUS_INFINITY;
@@ -478,7 +486,7 @@ __kernel void reduce_min_stage2of2_cl(
         const    int    isize,
         __global real  *scratch,
         __local  real  *tile)
-{       
+{
    const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
 
@@ -491,7 +499,7 @@ __kernel void reduce_min_stage2of2_cl(
    for (giX += ntX; giX < isize; giX += ntX) {
      if (scratch[giX] < tile[tiX]) tile[tiX] = scratch[giX];
    }
- 
+
    barrier(CLK_LOCAL_MEM_FENCE);
 
    reduction_min_within_tile(tile);
@@ -501,94 +509,38 @@ __kernel void reduce_min_stage2of2_cl(
    }
 }
 
-void reduction_sum_within_tile(__local  real  *tile) 
+void reduction_sum_within_tile(__local  real  *tile)
 {
    const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
 
-    for (int offset=ntX>>1; offset > 32; offset >>= 1){
-      if (tiX < offset){
-        tile[tiX] += tile[tiX+offset];
-      }
-      barrier(CLK_LOCAL_MEM_FENCE);
-    }
-
-    if (tiX < 32){
-      tile[tiX] += tile[tiX+32];
-      tile[tiX] += tile[tiX+16];
-      tile[tiX] += tile[tiX+8];
-      tile[tiX] += tile[tiX+4];
-      tile[tiX] += tile[tiX+2];
-      tile[tiX] += tile[tiX+1];
-    }
+   REDUCE_IN_TILE(SUM);
 
 }
 
-void reduction_sum_int_within_tile(__local  int  *tile) 
+void reduction_sum_int_within_tile(__local  int  *tile)
 {
    const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
 
-    for (int offset=ntX>>1; offset > 32; offset >>= 1){
-      if (tiX < offset){
-        tile[tiX] += tile[tiX+offset];
-      }
-      barrier(CLK_LOCAL_MEM_FENCE);
-    }
-
-    if (tiX < 32){
-      tile[tiX] += tile[tiX+32];
-      tile[tiX] += tile[tiX+16];
-      tile[tiX] += tile[tiX+8];
-      tile[tiX] += tile[tiX+4];
-      tile[tiX] += tile[tiX+2];
-      tile[tiX] += tile[tiX+1];
-    }
+   REDUCE_IN_TILE(SUM_INT);
 
 }
 
-void reduction_max_within_tile(__local  real  *tile) 
+void reduction_max_within_tile(__local  real  *tile)
 {
    const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
 
-    for (int offset=ntX>>1; offset > 32; offset >>= 1){
-      if (tiX < offset){
-        if (tile[tiX+offset] > tile[tiX]) tile[tiX] = tile[tiX+offset];
-      }
-      barrier(CLK_LOCAL_MEM_FENCE);
-    }
-
-    if (tiX < 32){
-      if (tile[tiX+32] > tile[tiX]) tile[tiX] = tile[tiX+32];
-      if (tile[tiX+16] > tile[tiX]) tile[tiX] = tile[tiX+16];
-      if (tile[tiX+8] > tile[tiX]) tile[tiX] = tile[tiX+8];
-      if (tile[tiX+4] > tile[tiX]) tile[tiX] = tile[tiX+4];
-      if (tile[tiX+2] > tile[tiX]) tile[tiX] = tile[tiX+2];
-      if (tile[tiX+1] > tile[tiX]) tile[tiX] = tile[tiX+1];
-    }
+   REDUCE_IN_TILE(MAX);
 
 }
 
-void reduction_min_within_tile(__local  real  *tile) 
+void reduction_min_within_tile(__local  real  *tile)
 {
    const unsigned int tiX  = get_local_id(0);
    const unsigned int ntX  = get_local_size(0);
 
-    for (int offset=ntX>>1; offset > 32; offset >>= 1){
-      if (tiX < offset){
-        if (tile[tiX+offset] < tile[tiX]) tile[tiX] = tile[tiX+offset];
-      }
-      barrier(CLK_LOCAL_MEM_FENCE);
-    }
-
-    if (tiX < 32){
-      if (tile[tiX+32] < tile[tiX]) tile[tiX] = tile[tiX+32];
-      if (tile[tiX+16] < tile[tiX]) tile[tiX] = tile[tiX+16];
-      if (tile[tiX+8] < tile[tiX]) tile[tiX] = tile[tiX+8];
-      if (tile[tiX+4] < tile[tiX]) tile[tiX] = tile[tiX+4];
-      if (tile[tiX+2] < tile[tiX]) tile[tiX] = tile[tiX+2];
-      if (tile[tiX+1] < tile[tiX]) tile[tiX] = tile[tiX+1];
-    }
+   REDUCE_IN_TILE(MIN);
 
 }

--- a/state.cpp
+++ b/state.cpp
@@ -245,7 +245,7 @@ void State::init(int do_gpu_calc)
 #ifdef HAVE_OPENCL
       cl_context context = ezcl_get_context();
 
-      if (ezcl_get_compute_device() == COMPUTE_DEVICE_ATI) printf("Starting compile of kernels in state\n");
+      printf("Starting compile of kernels in state\n");
       const char *defines = NULL;
       cl_program program                 = ezcl_create_program_wsource(context, defines, state_kern_source);
 
@@ -264,7 +264,7 @@ void State::init(int do_gpu_calc)
       kernel_reduce_epsum_mass_stage2of2     = ezcl_create_kernel_wprogram(program, "reduce_epsum_mass_stage2of2_cl");
 
       ezcl_program_release(program);
-      if (ezcl_get_compute_device() == COMPUTE_DEVICE_ATI) printf("Finishing compile of kernels in state\n");
+      printf("Finishing compile of kernels in state\n");
 #endif
    }
 

--- a/state_kern.cl
+++ b/state_kern.cl
@@ -180,7 +180,7 @@ real_t MIN(real_t a, real_t b)
         }                                                                       \
         barrier(CLK_LOCAL_MEM_FENCE);                                           \
     }                                                                           \
-    if (tiX < 32)                                                               \
+    if (tiX < MIN_REDUCE_SYNC_SIZE)                                             \
     {                                                                           \
         for (int offset = MIN_REDUCE_SYNC_SIZE; offset > 1; offset >>= 1)       \
         {                                                                       \

--- a/state_kern.cl
+++ b/state_kern.cl
@@ -1472,7 +1472,8 @@ __kernel void calc_finite_difference_cl(
                        Vxfluxplus, Vxfluxminus, Vyfluxplus, Vyfluxminus)
                   - wminusy_V + wplusy_V;
 
-#ifdef ATI
+#if 0
+   // XXX AMD seems to be fine on this bit
    // ATI fails on correction terms
    Hic += -(deltaT / dxic)*(Hxfluxplus - Hxfluxminus + Hyfluxplus - Hyfluxminus);
    //Hic += -wminusx_H + wplusx_H - wminusy_H + wplusy_H;
@@ -1489,11 +1490,9 @@ __kernel void calc_finite_difference_cl(
    
 
     //  Write values for the main cell back to global memory.
-#ifdef IS_NVIDIA
     H_new[giX] = Hic;
     U_new[giX] = Uic;
     V_new[giX] = Vic;
-#endif
 
 //////////////////////////////////////////////////////////////////
 ////////////////////          END           //////////////////////


### PR DESCRIPTION
Some of the kernels had hardcoded 'warp' sizes of 32 for NVIDIA hardware - I have removed these and now the size can be either 32 for NVIDIA hardware and 64 for AMD hardware.

I have tested it with clamr_gpucheck on various NVIDIA and AMD hardware, with MPI, and it seems to work fine.

The only thing I'm not sure about is in clamr_gpuonly.cpp, with the 'enhanced precision' sum on AMD hardware - I don't know if it's required any more but I've left it there just in case